### PR TITLE
Update lc4.py

### DIFF
--- a/lc4/lc4.py
+++ b/lc4/lc4.py
@@ -16,7 +16,7 @@ with open(version_txt, 'r') as f:
 # ************************************************************
 
 _major_version = sys.version_info.major
-if _major_version not in (2, 3):
+if _major_version < 2:
     raise RuntimeError("Unsupported version of Python: {}".format(_major_version))
 
 


### PR DESCRIPTION
When Python 4 comes out, such packages become automatically obsolete.